### PR TITLE
Adding consume decorators

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -782,6 +782,12 @@ class Api(object):
         return wrapper
 
     def consume(self, mediatype):
+        '''
+        For adding new request media types.
+        We coudl add the media type on the swagger ui, it will require
+        to implement the validation or the configuration depending on
+        the data type you pass to the decorator.
+        '''
         def wrapper(func):
             self.consumes[mediatype] = func
             return func


### PR DESCRIPTION
Adding consume decorator for having a decorator to add response types on the swagger ui of the api.